### PR TITLE
src: Reformat EmptyState for eslint-plugin-react 7.29.x

### DIFF
--- a/src/emptyState.jsx
+++ b/src/emptyState.jsx
@@ -57,7 +57,8 @@ class EmptyState extends React.Component {
                        paragraph={ errorMessage }
                        secondary={ troubleshoot }
                        action={ _("Start the certificate service") }
-                       onAction={ () => this.startCertmonger() } />;
+                       onAction={ () => this.startCertmonger() }
+            />;
         }
     }
 }


### PR DESCRIPTION
The expected indentation of self-closing tags became stricter with
current eslint-plugin-react versions.

---

See [this failure](https://logs.cockpit-project.org/logs/pull-2960-20220228-052734-fa4d4ff4-fedora-35-cockpit-project-cockpit-certificates/log.html)