### PR TITLE
spec: use nodejs-devel only on Fedora

### DIFF
--- a/packaging/cockpit-certificates.spec.in
+++ b/packaging/cockpit-certificates.spec.in
@@ -9,7 +9,10 @@ Source0:        https://github.com/cockpit-project/cockpit-certificates/releases
 Source1:        https://github.com/cockpit-project/cockpit-certificates/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch:      noarch
 ExclusiveArch:  %{nodejs_arches} noarch
+%if 0%{?fedora}
 BuildRequires:  nodejs-devel
+%endif
+BuildRequires: nodejs
 BuildRequires:  libappstream-glib
 BuildRequires:  make
 BuildRequires: gettext


### PR DESCRIPTION
According to the Fedora guidelines, nodejs-devel is needed for using
nodejs modules:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Node.js/#_buildrequires

Since this applies only on Fedora, and that nodejs-devel may not even
exist on other distros (e.g. CentOS 9 Stream), then limit the
nodejs-devel requirement only to Fedora, using nodejs unconditionally
everywhere.