### PR TITLE
Fedora Packaging fixes v2

### DIFF
--- a/packaging/cockpit-certificates.spec.in
+++ b/packaging/cockpit-certificates.spec.in
@@ -31,8 +31,7 @@ Provides: bundled(nodejs-react) = 16.14.0
 Cockpit component for managing certificates with certmonger.
 
 %prep
-%setup -q -n %{name}
-%setup -q -a 1 -n %{name}
+%autosetup -n %{name} -a 1
 # ignore pre-built webpack in release tarball and rebuild it
 rm -rf dist
 

--- a/packaging/cockpit-certificates.spec.in
+++ b/packaging/cockpit-certificates.spec.in
@@ -41,9 +41,10 @@ gzip -cd dist/index.js.LICENSE.txt.gz > LICENSE
 
 %install
 %make_install
-appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 %check
+appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
+
 # this can't be meaningfully tested during package build; tests happen through
 # FMF (see plans/all.fmf) during package gating
 


### PR DESCRIPTION
Forwardport of https://github.com/cockpit-project/starter-kit/pull/575 to cockpit-certificates;
will be needed for https://bugzilla.redhat.com/show_bug.cgi?id=1969450