### PR TITLE
Fix #97

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make
 
 # Installing
 
-`make install` compiles and installs the package in `/usr/share/cockpit/`. The
+`sudo make install` compiles and installs the package in `/usr/share/cockpit/`. The
 convenience targets `srpm` and `rpm` build the source and binary rpms,
 respectively. Both of these make use of the `dist` target, which is used
 to generate the distribution tarball. In `production` mode, source files are


### PR DESCRIPTION
The installation writes to `/usr/share/cockpit/` which is owned by root
with 755 permissions. Therefore, `sudo` is required.