### PR TITLE
Bump Cockpit API to include Python 3.11 compatibility fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 4ac3051d86db4f9061e35ce0584b688b1c8115e4; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
This will fix tests on all Rawhide, Fedora 35 & 36.