### PR TITLE
packit.yaml: drop deprecated metadata key

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -16,6 +16,5 @@ actions:
 jobs:
   - job: tests
     trigger: pull_request
-    metadata:
-      targets:
+    targets:
       - fedora-all


### PR DESCRIPTION
The packit docs no longer mention the metadat key as required.
https://packit.dev/docs/configuration/#supported-jobs