### PR TITLE
Fix misplaced hasNoPaddingTop property

### DIFF
--- a/src/certificateActions.jsx
+++ b/src/certificateActions.jsx
@@ -79,8 +79,8 @@ export const RemoveModal = ({ onClose, certs, cert, certPath, addAlert, appOnVal
                 </samp>
             </FormGroup>
 
-            <FormGroup label={_("Key file")}>
-                <samp id={idPrefix + "key-file"} hasNoPaddingTop>
+            <FormGroup label={_("Key file")} hasNoPaddingTop>
+                <samp id={idPrefix + "key-file"}>
                     {cert["key-file"].v}
                 </samp>
             </FormGroup>


### PR DESCRIPTION
This was found by a update to one of the build tools:

    ERROR in
    /home/mvo/work/cockpit-certificates/src/certificateActions.jsx
      83:50  error  Unknown property 'hasNoPaddingTop' found  react/no-unknown-property