### PR TITLE
build: Move to a webpack module, generalize bundler language/variable names

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -13,7 +13,7 @@ Cockpit Certificates git repository checkout.
 Cockpit Certificates uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.jsx` and `.js` files.
 
-The linter is executed within every build as a webpack preloader.
+eslint is executed within every build.
 
 For developer convenience, the ESLint can be started explicitly by:
 

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json
-# one example file in dist/ from webpack to check if that already ran
-WEBPACK_TEST=dist/manifest.json
+# one example file in dist/ from bundler to check if that already ran
+DIST_TEST=dist/manifest.json
 # one example file in pkg/lib to check if it was already checked out
 COCKPIT_REPO_STAMP=pkg/lib/cockpit-po-plugin.js
 # common arguments for tar, mostly to make the generated tarballs reproducible
 TAR_ARGS = --sort=name --mtime "@$(shell git show --no-patch --format='%at')" --mode=go=rX,u+rw,a-s --numeric-owner --owner=0 --group=0
 
-all: $(WEBPACK_TEST)
+all: $(DIST_TEST)
 
 # checkout common files from Cockpit repository required to build this project;
 # this has no API stability guarantee, so check out a stable tag when you start
@@ -83,18 +83,18 @@ po/LINGUAS:
 %.spec: packaging/%.spec.in
 	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
 
-$(WEBPACK_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
+$(DIST_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
 	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 
 watch:
-	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
+	NODE_ENV=$(NODE_ENV) npm run watch
 
 clean:
 	rm -rf dist/
 	rm -f $(SPEC)
 	rm -f po/LINGUAS
 
-install: $(WEBPACK_TEST) po/LINGUAS
+install: $(DIST_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	mkdir -p $(DESTDIR)/usr/share/metainfo/
@@ -103,7 +103,7 @@ install: $(WEBPACK_TEST) po/LINGUAS
 		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
 
 # this requires a built source tree and avoids having to install anything system-wide
-devel-install: $(WEBPACK_TEST)
+devel-install: $(DIST_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
@@ -115,12 +115,12 @@ devel-uninstall:
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
-# when building a distribution tarball, call webpack with a 'production' environment
+# when building a distribution tarball, call bundler with a 'production' environment
 # we don't ship node_modules for license and compactness reasons; we ship a
 # pre-built dist/ (so it's not necessary) and ship package-lock.json (so that
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
-$(TARFILE): $(WEBPACK_TEST) $(SPEC)
+$(TARFILE): $(DIST_TEST) $(SPEC)
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
 		--exclude packaging/$(SPEC).in --exclude node_modules \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = e1969f1027e381d64d80508aee86f1c2cd61bb18 # 284 + logind sessions cleanup
+COCKPIT_REPO_COMMIT = 54f2fd58a3645c4a222e2b1b9b5f1b9321bed998 # 285 + Move to a webpack module
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
@@ -62,10 +62,10 @@ po/$(PACKAGE_NAME).js.pot:
 		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/html2po -o $@ $$(find src -name '*.html')
+	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/manifest2po src/manifest.json -o $@
+	pkg/lib/manifest2po.js src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).metainfo.pot: $(APPSTREAMFILE)
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ your browser.
 
 You can also use
 [watch mode](https://webpack.js.org/guides/development/#using-watch-mode) to
-automatically update the webpack on every code change with
+automatically update the bundle on every code change with
 
     $ npm run watch
 
@@ -49,7 +49,7 @@ or
 
     $ make watch
 
-When developing against a virtual machine, webpack can also automatically upload
+When developing against a virtual machine, watch mode can also automatically upload
 the code changes by setting the `RSYNC` environment variable to
 the remote hostname.
 
@@ -65,7 +65,7 @@ remove manually the symlink:
 cockpit-certificates uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.js` and `.jsx` files.
 
-The linter is executed within every build as a webpack preloader.
+eslint is executed within every build.
 
 For developer convenience, the ESLint can be started explicitly by:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "certificates",
   "description": "Scaffolding for a cockpit module",
+  "type": "module",
   "main": "index.js",
   "repository": "git@github.com:skobyda/certificates.git",
   "author": "",

--- a/packaging/cockpit-certificates.spec.in
+++ b/packaging/cockpit-certificates.spec.in
@@ -32,7 +32,7 @@ Cockpit component for managing certificates with certmonger.
 
 %prep
 %autosetup -n %{name} -a 1
-# ignore pre-built webpack in release tarball and rebuild it
+# ignore pre-built bundle in release tarball and rebuild it
 rm -rf dist
 
 %build

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -16,6 +16,11 @@ chmod a+w "$LOGS"
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
 dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
+# nodejs 10 is too old for current Cockpit test API
+if grep -q platform:el8 /etc/os-release; then
+    dnf module switch-to -y nodejs:16
+fi
+
 # create user account for logging in
 if ! id admin 2>/dev/null; then
     useradd -c Administrator -G wheel admin

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
 
-const copy = require("copy-webpack-plugin");
-const extract = require("mini-css-extract-plugin");
-const TerserJSPlugin = require('terser-webpack-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const CompressionPlugin = require("compression-webpack-plugin");
-const ESLintPlugin = require('eslint-webpack-plugin');
-const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
-const CockpitRsyncPlugin = require("./pkg/lib/cockpit-rsync-plugin");
+import copy from "copy-webpack-plugin";
+import extract from "mini-css-extract-plugin";
+import TerserJSPlugin from 'terser-webpack-plugin';
+import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+import CompressionPlugin from "compression-webpack-plugin";
+import ESLintPlugin from 'eslint-webpack-plugin';
+
+import CockpitPoPlugin from "./pkg/lib/cockpit-po-plugin.js";
+import CockpitRsyncPlugin from "./pkg/lib/cockpit-rsync-plugin.js";
 
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
@@ -23,13 +23,13 @@ const copy_files = [
 ];
 const plugins = [
     new copy({ patterns: copy_files }),
-    new extract({filename: "[name].css"}),
+    new extract({ filename: "[name].css" }),
     new ESLintPlugin({
         extensions: ["js", "jsx"],
         failOnWarning: true,
     }),
     new CockpitPoPlugin(),
-    new CockpitRsyncPlugin({dest: packageJson.name}),
+    new CockpitRsyncPlugin({ dest: packageJson.name }),
 ];
 
 /* Only minimize when in production mode */
@@ -40,7 +40,7 @@ if (production) {
     }));
 }
 
-module.exports = {
+const config = {
     mode: production ? 'production' : 'development',
     entry: {
         index: [
@@ -48,13 +48,13 @@ module.exports = {
         ]
     },
     resolve: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
         alias: { 'font-awesome': 'font-awesome-sass/assets/stylesheets' },
     },
     resolveLoader: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
     },
-    externals: { "cockpit": "cockpit" },
+    externals: { cockpit: "cockpit" },
     devtool: "source-map",
 
     optimization: {
@@ -161,4 +161,6 @@ module.exports = {
         ]
     },
     plugins: plugins
-}
+};
+
+export default config;


### PR DESCRIPTION
Cockpit recently changed to an ESM build system [1]. Bump COCKPIT_REPO_COMMIT to that and follow suit.

This does not work with old node.js 10 any more which is still the default in RHEL 8. Install the newer version 16 instead.

[1] https://github.com/cockpit-project/cockpit/pull/18366

-----

Pretty much identical to https://github.com/cockpit-project/starter-kit/pull/625