### PR TITLE
Use whole path in patternfly imports

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -21,10 +21,9 @@ import cockpit from "cockpit";
 import React from "react";
 import "./app.scss";
 
-import {
-    Alert, AlertGroup, AlertActionCloseButton, AlertVariant,
-    Page, PageSection, PageSectionVariants,
-} from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+import { AlertGroup } from "@patternfly/react-core/dist/esm/components/AlertGroup/index.js";
+import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 
 import EmptyState from "./emptyState.jsx";
 import { getRequests, getRequest, getCAs, getCA } from './dbus.js';

--- a/src/certificateActions.jsx
+++ b/src/certificateActions.jsx
@@ -22,15 +22,11 @@ import React, { useState } from "react";
 
 import "./certificateActions.css";
 
-import {
-    Button,
-    Checkbox,
-    Dropdown,
-    DropdownItem,
-    Form, FormGroup,
-    KebabToggle,
-    Modal,
-} from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
+import { Dropdown, DropdownItem, KebabToggle } from "@patternfly/react-core/dist/esm/components/Dropdown/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 
 import { ResubmitCertificateModal } from './requestCertificate.jsx';
 import { removeRequest } from "./dbus.js";

--- a/src/certificateList.jsx
+++ b/src/certificateList.jsx
@@ -20,14 +20,11 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import {
-    Badge,
-    Checkbox,
-    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
-    Flex, FlexItem,
-    Tooltip,
-    TooltipPosition
-} from "@patternfly/react-core";
+import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 import { InfoAltIcon, ExclamationTriangleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 
 import { CertificateActions } from "./certificateActions.jsx";

--- a/src/emptyState.jsx
+++ b/src/emptyState.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
-import { Button } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 

--- a/src/requestCertificate.jsx
+++ b/src/requestCertificate.jsx
@@ -19,16 +19,14 @@
 import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";
 
-import {
-    Button,
-    Checkbox,
-    Form, FormGroup,
-    FormSelect, FormSelectOption,
-    Modal,
-    Radio,
-    TextArea,
-    TextInput
-} from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
+import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
 import { addRequest, modifyRequest, resubmitRequest } from "./dbus.js";
 import { ModalError } from "cockpit-components-inline-notification.jsx";


### PR DESCRIPTION
Otherwise we rely on treeshaking mechanisms to remove unused code, thus making our bundle size more vulnerable to bundler's ability to drop dead code.