### PR TITLE
test: Account for leap years

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -166,7 +166,8 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
-        next_year = datetime.datetime.now() + datetime.timedelta(days=365)
+        date_now = datetime.datetime.now()
+        next_year = date_now.replace(year = date_now.year + 1)
         next_year_str = next_year.strftime('%-m/%-d/%Y')
 
         cert_name = "Server-Cert"
@@ -237,7 +238,8 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
-        next_year = datetime.datetime.now() + datetime.timedelta(days=365)
+        date_now = datetime.datetime.now()
+        next_year = date_now.replace(year = date_now.year + 1)
         next_year_str = next_year.strftime('%-m/%-d/%Y')
 
         cert_path = "/etc/pki/tls/certs/myCert.cert"


### PR DESCRIPTION
Adding just 365 days to a current date is not a good way to a get a next year's date, since it doesn't account for leap years. This started to fail the tests, since next year (2024) is a leap year:
`wait_js_cond(ph_in_text("#certificate-0-validity","Auto-renews before 3/1/2024")): Uncaught (in promise) Error: actual text: Auto-renews before 3/2/2024, 7:30:34 am`

Fixes image-refresh: https://github.com/cockpit-project/bots/pull/4478