### PR TITLE
Revert "spec: use nodejs-devel only on Fedora", Revert "spec: Fix BuildRequires: to nodejs-devel"

### DIFF
--- a/packaging/cockpit-certificates.spec.in
+++ b/packaging/cockpit-certificates.spec.in
@@ -9,9 +9,6 @@ Source0:        https://github.com/cockpit-project/cockpit-certificates/releases
 Source1:        https://github.com/cockpit-project/cockpit-certificates/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch:      noarch
 ExclusiveArch:  %{nodejs_arches} noarch
-%if 0%{?fedora}
-BuildRequires:  nodejs-devel
-%endif
 BuildRequires: nodejs
 BuildRequires:  libappstream-glib
 BuildRequires:  make


### PR DESCRIPTION
This reverts commits 9734f58d5ad80f5d413dc5b7ef6294949978daeb and 097ea95f869db6deab6ef5aa5f1d94496c485cf5.

For the last couple of weeks, nodejs-devel has been uninstallable in COPR, as it has a different major version than nodejs. This was only introduced as a formality, not because we actually need it.