### PR TITLE
packit: Move to nodejs-npm SRPM dependency

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -5,7 +5,7 @@
 specfile_path: cockpit-certificates.spec
 srpm_build_deps:
 - make
-- npm
+- nodejs-npm
 actions:
   post-upstream-clone:
     - make cockpit-certificates.spec


### PR DESCRIPTION
`npm` recently became broken in Fedora and doesn't provide the `npm` binary any more. As a workaround, move to `nodejs-npm` to fix the srpm build.

Cherry-picked from starter-kit commit c499257ec86b30.