### PR TITLE
Update shared cockpit files for Chromium 113 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 269bf89276c679a03befc8a04244addd5d810048 # 290 + 42 commits
+COCKPIT_REPO_COMMIT = 30eeca9eeabdf9a2f837151992d40b88d0f34cd3 # 290 + chromium 113 sizzle fix
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'


### PR DESCRIPTION
The most recent Chromium 113 does not work any more with sizzle, tests were hanging as soon as they switched to a frame. The latest cockpit testlib applied a workaround [1]. As the latest Cockpit library also moved to PatternFly 5, but we haven't transitioned to that yet, switch to the (temporary) "290+chromium-sizzle" branch, which has that workaround backported.

[1] https://github.com/cockpit-project/cockpit/pull/18812