### PR TITLE
package.json: drop flowtype plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "parserOptions": {
         "ecmaVersion": 2022
     },
-    "plugins": ["flowtype", "react", "react-hooks", "jsx-a11y"],
+    "plugins": ["react", "react-hooks", "jsx-a11y"],
     "rules": {
         "indent": ["error", 4,
             {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "eslint-config-standard": "17.1.0",
     "eslint-config-standard-jsx": "11.0.0",
     "eslint-config-standard-react": "13.0.0",
-    "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-import": "2.28.1",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-promise": "6.1.1",


### PR DESCRIPTION
None of the Cockpit projects use flowtype's type annotation.