### PR TITLE
package.json: drop cssnano-preset-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "chrome-remote-interface": "0.33.0",
-    "cssnano-preset-lite": "3.0.0",
     "esbuild": "0.19.4",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-replace": "1.4.0",


### PR DESCRIPTION
After the switch to esbuild nothing requires this.