### PR TITLE
Correctly pass certificate changes to setState

### DIFF
--- a/src/certificateActions.jsx
+++ b/src/certificateActions.jsx
@@ -39,7 +39,7 @@ export const RemoveModal = ({ onClose, certs, cert, certPath, addAlert, appOnVal
     const onRemoveResponse = () => {
         delete certs[certPath];
 
-        appOnValueChanged("certs, certs");
+        appOnValueChanged("certs", certs);
         onClose();
     };
 


### PR DESCRIPTION
This was flaky causing certificate removal changes not to be noticed in CI as the certs state was not always updated in app.jsx